### PR TITLE
entry.hit: fix panic on integer overflow

### DIFF
--- a/src/entry.zig
+++ b/src/entry.zig
@@ -65,7 +65,9 @@ pub fn Entry(comptime T: type) type {
 
 		pub fn hit(self: *Self) u8 {
 			// wrapping is fine.
-			return @atomicRmw(u8, &self._gets, .Add, 1, .monotonic) + 1;
+			const prev = @atomicRmw(u8, &self._gets, .Add, 1, .monotonic);
+			const result, _ = @addWithOverflow(prev, 1);
+			return result;
 		}
 
 		pub fn borrow(self: *Self) void {


### PR DESCRIPTION
Previously entry.hit() returned `@atomicRmw(u8, &self._gets, .Add, 1, .monotonic) + 1`.

While the @atomicRmw does not cause panic due to overflow, the ` + 1` will cause an panic on overflow.

Instead replace the `+ 1` with @addWithOverflow.